### PR TITLE
make it compile on macOS (intel)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ build/
 
 # OS specific
 .DS_Store
+
+# VS Code
+.vscode
+.cache
+
+# Stranded II folder
+stranded2_en.zip
+stranded2_en

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,18 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.20)
+
+# C++ Settings
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Werror -pedantic")
+if (APPLE)
+	# First flag fixes this:
+	# 	Definition of implicit copy assignment operator for 'Program' is deprecated because it has a user-declared copy constructor
+	# 	at: source/engine/script/Program.h, line 13.
+	# Second one removes OpenGL warnings
+	# Other two are used to fix:
+	#	arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension
+	#	at: source/graphics/device/OpenGLDevice.cpp, line 25.
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy -Wno-deprecated-declarations -Wno-gnu -Wno-null-pointer-arithmetic")
+endif()
 
 project(Stranded2pp)
 
@@ -14,7 +28,14 @@ include_directories(source)
 
 file(GLOB_RECURSE SOURCES source/*.cpp)
 
-add_definitions(-std=c++14 -Wall -Wextra -Werror -pedantic)
+
+if (APPLE)
+	# First is for this:
+	# Definition of implicit copy assignment operator for 'Program' is deprecated because it has a user-declared copy constructor
+	# at: source/engine/script/Program.h, line 13.
+	# Second one removes OpenGL warnings
+	add_definitions(-Wno-deprecated-copy -Wno-deprecated-declarations -Wno-gnu -Wno-null-pointer-arithmetic)
+endif()
 
 add_executable(stranded2pp ${SOURCES})
 

--- a/source/Stranded.cpp
+++ b/source/Stranded.cpp
@@ -129,9 +129,13 @@ void Stranded::printWelcomeMessage()
 	std::cout << std::string(80, '*');
 	std::cout << "\n";
 	std::cout << "Welcome to Stranded2++\n";
-	std::cout << "Web: www.github.com/SMemsky/Stranded2pp\n";
+	std::cout << "Made by dexter3k:\n";
+	std::cout << "Web: https://github.com/dexter3k/Stranded2pp\n";
 	std::cout << "Mail: schooldev3000@gmail.com\n";
 	std::cout << "Original game: www.stranded.unrealsoftware.de\n";
+	std::cout << "\n";
+	std::cout << "Contributors:\n";
+	std::cout << "Alepacho (https://github.com/Alepacho)\n";
 	std::cout << std::string(80, '*');
 	std::cout << "\n" << std::endl;
 }

--- a/source/graphics/Texture.cpp
+++ b/source/graphics/Texture.cpp
@@ -2,6 +2,9 @@
 
 #include <iostream>
 
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION 1
+#endif // __APPLE__
 #include "device/OpenGLDevice.h"
 
 namespace gfx

--- a/source/graphics/device/OpenGLDevice.h
+++ b/source/graphics/device/OpenGLDevice.h
@@ -3,6 +3,9 @@
 #include <cstdint>
 #include <map>
 
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION 1
+#endif // __APPLE__
 #include <SFML/OpenGL.hpp>
 
 #include "Device.h"


### PR DESCRIPTION
First flag fixes this:
`Definition of implicit copy assignment operator for 'Program' is deprecated because it has a user-declared copy constructor`
at: `source/engine/script/Program.h, line 13.`

Second one removes OpenGL warnings (GL_SILENCE_DEPRECATION)

Other two are used to fix:
`arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension`
at: `source/graphics/device/OpenGLDevice.cpp, line 25.`

